### PR TITLE
Support for move to vtop

### DIFF
--- a/autocaptcha-for-chrome/manifest.json
+++ b/autocaptcha-for-chrome/manifest.json
@@ -2,15 +2,15 @@
   "name": "AutoCaptcha for VITacademics",
   "version": "0.3.5",
   "author": "Karthik Balakrishnan",
-  "description": "Fills in the captcha for you at VIT's Academics page (academics.vit.ac.in)",
+  "description": "Fills in the captcha for you at VIT's Academics page (vtop.vit.ac.in)",
   "permissions": ["*://academics.vit.ac.in/*"],
   "content_scripts": [
     {
-      "matches": ["*://academics.vit.ac.in/parent/parent_login.asp","*://academics.vit.ac.in/student/stud_login.asp","*://academics.vit.ac.in/parent/","*://academics.vit.ac.in/student/","*://27.251.102.132/parent/parent_login.asp","*://27.251.102.132/student/stud_login.asp","*://27.251.102.132/parent/","*://27.251.102.132/student/"],
+      "matches": ["*://vtop.vit.ac.in/parent/parent_login.asp","*://vtop.vit.ac.in/student/stud_login.asp","*://vtop.vit.ac.in/parent/","*://vtop.vit.ac.in/student/","*://27.251.102.132/parent/parent_login.asp","*://27.251.102.132/student/stud_login.asp","*://27.251.102.132/parent/","*://27.251.102.132/student/"],
       "js": ["captcha.js"]
     },
     {
-      "matches": ["*://academics.vit.ac.in/*/attn_report.asp*","*://27.251.102.132/*/attn_report.asp*"],
+      "matches": ["*://vtop.vit.ac.in/*/attn_report.asp*","*://27.251.102.132/*/attn_report.asp*"],
       "all_frames": true,
       "js": ["attendance.js"]
     }

--- a/autocaptcha-for-firefox/lib/main.js
+++ b/autocaptcha-for-firefox/lib/main.js
@@ -2,12 +2,12 @@
 var pageMod = require("sdk/page-mod");
 var self = require("sdk/self");
 pageMod.PageMod({
-  include: ["https://academics.vit.ac.in/parent/parent_login.asp","https://academics.vit.ac.in/student/stud_login.asp","https://academics.vit.ac.in/parent/","https://academics.vit.ac.in/student/","https://27.251.102.132/parent/parent_login.asp","https://27.251.102.132/student/stud_login.asp","https://27.251.102.132/parent/","https://27.251.102.132/student/"],
+  include: ["https://vtop.vit.ac.in/parent/parent_login.asp","https://vtop.vit.ac.in/student/stud_login.asp","https://vtop.vit.ac.in/parent/","https://vtop.vit.ac.in/student/","https://27.251.102.132/parent/parent_login.asp","https://27.251.102.132/student/stud_login.asp","https://27.251.102.132/parent/","https://27.251.102.132/student/"],
   contentScriptFile: self.data.url("captcha.js")
 });
 
 pageMod.PageMod({
-  include: /http(s)+:\/\/(academics.vit.ac.in)|(27.251.102.132)\/(.)*\/attn_report.asp(.)*/,
+  include: /http(s)+:\/\/(vtop.vit.ac.in)|(27.251.102.132)\/(.)*\/attn_report.asp(.)*/,
   contentScriptFile: self.data.url("attendance.js"),
   attachTo: ["existing","top","frame"]
 });


### PR DESCRIPTION
Noticed that the extension had stopped working today because of the move to vtop.ac.in. Any academics.vit.ac.in url redirects there as well.